### PR TITLE
limit redis to 1gb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 200M 
     network_mode: host
 volumes:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,10 @@ services:
     volumes:
       - redis_data:/data
     restart: ${RESTART_POLICY:-always}
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     network_mode: host
 volumes:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
     volumes:
       - redis_data:/data
     restart: ${RESTART_POLICY:-always}
+    command: ["redis-server", "--appendonly", "no", "--maxmemory", "100mb", "--maxmemory-policy", "allkeys-lru"]
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Following the documentation of the deploy configuration in docker-compose, we can limit resources to a specific container.

In this case we are limiting the redis database to only 1Gb of memory.

https://docs.docker.com/reference/compose-file/deploy/#resources

To test if you can do:
````bash
docker compose up redis -d
docker stats # to see that the memory has been limited to 1Gb
```

Also check for redis maxmemory and maxmemory-policy

```bash
redis-cli CONFIG get maxmemory
redis-cli CONFIG get maxmemory-policy
```