### PR TITLE
Add per-tenant Participando Authorization Handler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,5 @@ end
 group :development do
   gem "letter_opener_web"
   gem "rubocop-faker"
+  gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bigdecimal (4.1.2)
+    bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
     brakeman (8.0.5)
@@ -1073,6 +1074,11 @@ GEM
       dry-configurable (>= 0.13, < 2)
       jwt (>= 2.1, < 4)
       warden (~> 1.2)
+    web-console (4.2.1)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     web-push (3.1.0)
       jwt (~> 3.0)
       openssl (>= 3.0)
@@ -1125,6 +1131,7 @@ DEPENDENCIES
   letter_opener_web
   puma
   rubocop-faker
+  web-console
 
 CHECKSUMS
   actioncable (7.2.3) sha256=e15d17b245f1dfe7cafdda4a0c6f7ba8ebaab1af33884415e09cfef4e93ad4f9
@@ -1156,6 +1163,7 @@ CHECKSUMS
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   better_html (2.2.0) sha256=e68ab66ab09696b708333bbf35e8aa3c107500ba7892f528e2111624bdd8cf76
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
   brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
@@ -1466,6 +1474,7 @@ CHECKSUMS
   w3c_validators (1.3.7) sha256=2785f8138ad4d6c2cf9f2a49693390cc55a815a51f1b0ff40e35eed4ff8be746
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   warden-jwt_auth (0.12.0) sha256=a1a857f3f93da4e529c9c45d6d432578bd48e3b0313d2fa1ccd2bb767d9b2ec2
+  web-console (4.2.1) sha256=e7bcf37a10ea2b4ec4281649d1cee461b32232d0a447e82c786e6841fd22fe20
   web-push (3.1.0) sha256=501ab00340c58fb70dabda59f28a86b3cccb0930c6f1f30721b2a5b24de7187d
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131

--- a/README.md
+++ b/README.md
@@ -35,6 +35,29 @@ SMTP_PORT=XXXXXX
 DECIDIM_ENV=production
 ```
 
+### Municipal Census (Padrón) Configuration
+
+The Municipal Census service integration requires environment variables to be configured:
+
+```bash
+# Required
+PARTICIPANDO_URL=https://www.animsa.es/ws/padron/v1
+PARTICIPANDO_ENTITY_NIF=XXXXXXXX
+PARTICIPANDO_ENCRYPTION_VECTOR=XXXXXXXXXXXXXXXX  # 16-byte IV
+
+# Optional
+PARTICIPANDO_SOAP_NAMESPACE=http://tempuri.org/  # Defaults to http://tempuri.org/
+```
+
+**Important:** Each tenant organization must be configured individually through the admin panel at `/system/participando_organization_settings` with their own credentials:
+
+- Application identifier
+- Username
+- Password
+- Encryption key (32-byte AES-256 key)
+
+These tenant-specific settings are encrypted and stored in the database.
+
 ## Deploy
 
 ### Pull from Github Repository

--- a/app/commands/decidim/system/update_participando_organization_setting.rb
+++ b/app/commands/decidim/system/update_participando_organization_setting.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module System
+    class UpdateParticipandoOrganizationSetting < Decidim::Command
+      def initialize(form, user)
+        @form = form
+        @user = user
+      end
+
+      attr_reader :form, :user
+
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        @setting = Decidim.traceability.update!(
+          setting,
+          user,
+          application: form.application,
+          user: form.user,
+          password: form.password,
+          encryption_key: form.encryption_key
+        )
+
+        broadcast(:ok)
+      end
+
+      private
+
+      def organization
+        @form.current_organization
+      end
+
+      def setting
+        organization.participando_organization_setting || organization.build_participando_organization_setting
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/system/participando_organization_settings_controller.rb
+++ b/app/controllers/decidim/system/participando_organization_settings_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module System
+    # Controller that allows managing all the Admins.
+    #
+    class ParticipandoOrganizationSettingsController < Decidim::System::ApplicationController
+      helper_method :organizations, :current_organization, :current_setting
+      def index; end
+
+      def edit
+        @form = form(ParticipandoOrganizationSettingForm).from_model(current_setting)
+      end
+
+      def update
+        @form = form(ParticipandoOrganizationSettingForm).from_params(params, current_organization: current_organization)
+
+        UpdateParticipandoOrganizationSetting.call(@form, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("decidim.system.participando_organization_settings.update.success")
+            redirect_to action: :index
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("decidim.system.participando_organization_settings.update.error")
+            render :edit, status: :unprocessable_entity
+          end
+        end
+      end
+
+      private
+
+      def organizations
+        @organizations ||= Decidim::Organization.includes(:participando_organization_setting).all
+      end
+
+      def current_setting
+        @setting ||= current_organization.participando_organization_setting || current_organization.build_participando_organization_setting
+      end
+
+      def current_organization
+        Decidim::Organization.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/forms/decidim/system/participando_organization_setting_form.rb
+++ b/app/forms/decidim/system/participando_organization_setting_form.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module System
+    # A form object to be inherited to create and update organizations from the system dashboard.
+    #
+    class ParticipandoOrganizationSettingForm < Form
+      mimic :participando_organization_setting
+
+      attribute :application, String
+      attribute :user, String
+      attribute :password, String
+      attribute :encryption_key, String
+
+      validates :application, :user, :password, :encryption_key, presence: true
+    end
+  end
+end

--- a/app/models/concerns/has_participando_organization_setting.rb
+++ b/app/models/concerns/has_participando_organization_setting.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module HasParticipandoOrganizationSetting
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :participando_organization_setting, class_name: "ParticipandoOrganizationSetting", foreign_key: :decidim_organization_id, dependent: :destroy
+  end
+end

--- a/app/models/participando_organization_setting.rb
+++ b/app/models/participando_organization_setting.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ParticipandoOrganizationSetting < ApplicationRecord
+  include Decidim::Traceable
+
+  belongs_to :organization,
+             class_name: "Decidim::Organization",
+             foreign_key: :decidim_organization_id,
+             inverse_of: :participando_organization_setting
+
+  encrypt_attribute :application, type: :text
+  encrypt_attribute :user, type: :text
+  encrypt_attribute :password, type: :text
+  encrypt_attribute :encryption_key, type: :text
+
+  validates :decidim_organization_id, uniqueness: true
+  validates :application, :user, :password, :encryption_key, presence: true
+end

--- a/app/models/participando_organization_setting.rb
+++ b/app/models/participando_organization_setting.rb
@@ -16,4 +16,8 @@ class ParticipandoOrganizationSetting < ApplicationRecord
 
   validates :decidim_organization_id, uniqueness: true
   validates :application, :user, :password, :encryption_key, presence: true
+
+  def self.log_presenter_class_for(_log)
+    Decidim::AdminLog::ParticipandoOrganizationSettingPresenter
+  end
 end

--- a/app/models/participando_organization_setting.rb
+++ b/app/models/participando_organization_setting.rb
@@ -2,6 +2,7 @@
 
 class ParticipandoOrganizationSetting < ApplicationRecord
   include Decidim::Traceable
+  include Decidim::RecordEncryptor
 
   belongs_to :organization,
              class_name: "Decidim::Organization",

--- a/app/presenters/decidim/admin_log/participando_organization_setting_presenter.rb
+++ b/app/presenters/decidim/admin_log/participando_organization_setting_presenter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  module AdminLog
+    # This class holds the logic to present a `ParticipandoOrganizationSetting`
+    # for the `AdminLog` log.
+    class ParticipandoOrganizationSettingPresenter < Decidim::Log::BasePresenter
+      private
+
+      def diff_fields_mapping
+        {
+          application: :string,
+          user: :string,
+          password: :string,
+          encryption_key: :string
+        }
+      end
+
+      def i18n_params
+        super.merge(
+          organization_name: translated_attribute(resource_presenter.send(:resource).organization.name)
+        )
+      end
+
+      def action_string
+        "decidim.admin_log.participando_organization_setting.update"
+      end
+
+      def i18n_labels_scope
+        "activemodel.attributes.participando_organization_setting"
+      end
+    end
+  end
+end

--- a/app/services/participando_authorization_handler.rb
+++ b/app/services/participando_authorization_handler.rb
@@ -65,7 +65,7 @@ class ParticipandoAuthorizationHandler < Decidim::AuthorizationHandler
     return if citizen_found? && birthdate == date_of_birth
 
     errors.add(:base,
-               I18n.t("decidim.participando_authorization_handler.participando_service_verification"))
+               I18n.t("decidim.participando_authorization_handler.invalid"))
   end
 
   def response

--- a/app/services/participando_authorization_handler.rb
+++ b/app/services/participando_authorization_handler.rb
@@ -62,7 +62,7 @@ class ParticipandoAuthorizationHandler < Decidim::AuthorizationHandler
   def participando_service_verification
     return unless response
 
-    nil if citizen_found? && birthdate == date_of_birth
+    return if citizen_found? && birthdate == date_of_birth
 
     errors.add(:base, I18n.t("decidim.participando_authorization_handler.invalid"))
   end

--- a/app/services/participando_authorization_handler.rb
+++ b/app/services/participando_authorization_handler.rb
@@ -64,7 +64,7 @@ class ParticipandoAuthorizationHandler < Decidim::AuthorizationHandler
 
     nil if citizen_found? && birthdate == date_of_birth
 
-    # errors.add(:base, I18n.t("decidim.participando_authorization_handler.invalid"))
+    errors.add(:base, I18n.t("decidim.participando_authorization_handler.invalid"))
   end
 
   def response

--- a/app/services/participando_authorization_handler.rb
+++ b/app/services/participando_authorization_handler.rb
@@ -36,8 +36,6 @@ class ParticipandoAuthorizationHandler < Decidim::AuthorizationHandler
   private
 
   def birthdate
-    return unless response
-
     date = response.xpath("//FECHANAC")&.text
     return nil if date.blank?
 
@@ -62,17 +60,18 @@ class ParticipandoAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def participando_service_verification
-    return if citizen_found? && birthdate == date_of_birth
+    return unless response
 
-    errors.add(:base,
-               I18n.t("decidim.participando_authorization_handler.invalid"))
+    nil if citizen_found? && birthdate == date_of_birth
+
+    # errors.add(:base, I18n.t("decidim.participando_authorization_handler.invalid"))
   end
 
   def response
     return @response if defined?(@response)
 
     @response = begin
-      service = ParticipandoCensusWebservice.new
+      service = ParticipandoCensusWebservice.new(user.organization)
       service.check_person(
         document_type: document_type,
         document_number: document_number,

--- a/app/services/participando_census_webservice.rb
+++ b/app/services/participando_census_webservice.rb
@@ -32,7 +32,12 @@ class ParticipandoCensusWebservice
     nie: 3
   }.freeze
 
-  def initialize
+  attr_reader :organization
+
+  def initialize(organization)
+    @organization = organization
+    raise I18n.t("decidim.participando_authorization_handler.organization_setting_not_found", organization: organization.host) unless setting
+
     @url = ENV.fetch("PARTICIPANDO_URL")
     @entity_nif = ENV.fetch("PARTICIPANDO_ENTITY_NIF")
     @application = ENV.fetch("PARTICIPANDO_APPLICATION")
@@ -40,6 +45,10 @@ class ParticipandoCensusWebservice
     @password = ENV.fetch("PARTICIPANDO_PASSWORD")
     @encryption_key = ENV.fetch("PARTICIPANDO_ENCRYPTION_KEY")
     @encryption_vector = ENV.fetch("PARTICIPANDO_ENCRYPTION_VECTOR")
+  end
+
+  def setting
+    @setting ||= ParticipandoOrganizationSetting.find_by(organization: organization)
   end
 
   # Calls LogIn and returns the IDSESION string (valid for 8 minutes).

--- a/app/services/participando_census_webservice.rb
+++ b/app/services/participando_census_webservice.rb
@@ -11,18 +11,20 @@ require "digest"
 # Required ENV vars (see .rbenv-vars):
 #   PARTICIPANDO_URL              - webservice endpoint
 #   PARTICIPANDO_ENTITY_NIF       - CIF of the entity (CIFENTIDAD)
-#   PARTICIPANDO_APPLICATION      - application identifier (e.g. PMH-UDALA)
-#   PARTICIPANDO_USER             - username provided by ANIMSA
-#   PARTICIPANDO_PASSWORD         - base password provided by ANIMSA
-#   PARTICIPANDO_ENCRYPTION_KEY   - 32-byte AES-256 key provided by ANIMSA
 #   PARTICIPANDO_ENCRYPTION_VECTOR - 16-byte IV provided by ANIMSA
+#
+# Configuration is read from ParticipandoOrganizationSetting:
+#   application      - application identifier (e.g. PMH-UDALA)
+#   user             - username provided by ANIMSA
+#   password         - base password provided by ANIMSA
+#   encryption_key   - 32-byte AES-256 key provided by ANIMSA
 #
 # NOTE: The SOAP namespace and parameter name below ("strXmlLogin") should be
 # verified against the actual WSDL at PARTICIPANDO_URL?WSDL if the service
 # rejects requests.
 class ParticipandoCensusWebservice
   IDOPERACION = "NAVARRA_SEDE_PADRON_ComprobarPersona_WS"
-  SOAP_NAMESPACE = "http://tempuri.org/"
+  SOAP_NAMESPACE = ENV.fetch("PARTICIPANDO_SOAP_NAMESPACE", "http://tempuri.org/")
 
   # TIDEO values for document types
   DOCUMENT_TIDEO = {
@@ -40,15 +42,15 @@ class ParticipandoCensusWebservice
 
     @url = ENV.fetch("PARTICIPANDO_URL")
     @entity_nif = ENV.fetch("PARTICIPANDO_ENTITY_NIF")
-    @application = ENV.fetch("PARTICIPANDO_APPLICATION")
-    @user = ENV.fetch("PARTICIPANDO_USER")
-    @password = ENV.fetch("PARTICIPANDO_PASSWORD")
-    @encryption_key = ENV.fetch("PARTICIPANDO_ENCRYPTION_KEY")
+    @application = setting.application
+    @user = setting.user
+    @password = setting.password
+    @encryption_key = setting.encryption_key
     @encryption_vector = ENV.fetch("PARTICIPANDO_ENCRYPTION_VECTOR")
   end
 
   def setting
-    @setting ||= ParticipandoOrganizationSetting.find_by(organization: organization)
+    @setting ||= organization.participando_organization_setting
   end
 
   # Calls LogIn and returns the IDSESION string (valid for 8 minutes).

--- a/app/views/decidim/system/participando_organization_settings/edit.html.erb
+++ b/app/views/decidim/system/participando_organization_settings/edit.html.erb
@@ -1,0 +1,23 @@
+<% add_decidim_page_title(t(".title")) %>
+
+<% provide :title do %>
+  <h1 class="h1"><%= t ".title" %></h1>
+<% end %>
+
+<%= decidim_form_for(@form, url: decidim_system.participando_organization_setting_path(current_organization), method: :put) do |f| %>
+  <div class="form__wrapper">
+    <h2 class="h2"><%= organization_name(current_organization) %></h2>
+    <%= f.text_field :application, autofocus: true %>
+
+    <%= f.text_field :user %>
+
+    <%= f.text_field :password %>
+
+    <%= f.text_field :encryption_key %>
+  </div>
+
+
+  <div class="form__wrapper-block">
+    <%= f.submit t(".save"), class: "button button__sm md:button__lg button__primary" %>
+  </div>
+<% end %>

--- a/app/views/decidim/system/participando_organization_settings/index.html.erb
+++ b/app/views/decidim/system/participando_organization_settings/index.html.erb
@@ -1,0 +1,43 @@
+<% add_decidim_page_title(t(".title")) %>
+
+<% provide :title do %>
+  <h1 class="h1"><%= t ".title" %></h1>
+<% end %>
+
+<p class="text-lg"><%= t ".description" %></p>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= t("models.organization.fields.name", scope: "decidim.system") %></th>
+      <th class="text-left"><%= t(".participando_settings") %></th>
+      <th class="text-left"><%= t(".updated_at") %></th>
+      <th><%= t("actions.title", scope: "decidim.system") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% organizations.each do |organization| %>
+      <tr>
+        <td>
+          <%= link_to organization_name(organization), edit_participando_organization_setting_path(organization) %><br>
+          <%= organization.host %>
+        </td>
+        <% if organization.participando_organization_setting.present? %>
+          <td class="text-left">
+            <%= organization.participando_organization_setting.application %>
+          </td>
+          <td class="text-left">
+            <%=  l organization.participando_organization_setting&.updated_at, format: :short %>
+          </td>
+        <% else %>
+          <td colspan="2" class="text-left">
+            <%= t(".no_settings") %>
+          </td>
+        <% end %>
+        <td>
+          <%= link_to t("actions.edit", scope: "decidim.system"), edit_participando_organization_setting_path(organization) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/initializers/verifications.rb
+++ b/config/initializers/verifications.rb
@@ -1,8 +1,23 @@
 # frozen_string_literal: true
 
-# Multiselect for street verificator
+# ParticipandoAuthorizationHandler is a custom authorization handler that checks if a user is registered in the municipal census (padrón) using the ANIMSA-PMH web service.
+# It validates the user's personal information and document details against the census records to determine if they are authorized.
+# Requires to configure certain values in the /system panel for the organization, such as application identifier, user credentials, and encryption keys.
 Decidim::Verifications.register_workflow(:participando_authorization_handler) do |workflow|
   workflow.form = "ParticipandoAuthorizationHandler"
   workflow.renewable = true
   workflow.time_between_renewals = 5.minutes
+end
+
+# Admin menu
+Decidim.menu :system_menu do |menu|
+  menu.add_item :participando,
+                I18n.t("decidim.participando_authorization_handler.system_name"),
+                Decidim::System::Engine.routes.url_helpers.participando_organization_settings_path,
+                position: 4,
+                active: :inclusive
+end
+
+Rails.application.config.to_prepare do
+  Decidim::Organization.include HasParticipandoOrganizationSetting
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,8 +14,16 @@ en:
         second_surname: Second surname
   decidim:
     authorization_handlers:
+      admin:
+        participando_authorization_handler:
+          help:
+          - This authorization handler allows you to verify the identity of a citizen
+            through the Municipal Census service.
       participando_authorization_handler:
         explanation: Municipal Census data verification
+        fields:
+          birthdate: Date of birth
+          document_type: Document type
         name: Municipal Census
     participando_authorization_handler:
       connection_error: Could not connect to the municipal census service.
@@ -24,9 +32,8 @@ en:
         nif: NIF
         none: Without document
         passport: Passport
-      invalid_participando_service_verification: Person not found in the municipal
-        census.
+      invalid: Person not found in the municipal census.
   open_data: Open Data
-  open_government: Open Government of
+  open_government: Open Government of Navarra
   participation: Participation
   transparency: Transparency

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,12 @@ en:
           consulted
         province_id: Province
         second_surname: Second surname
+      participando_organization_setting:
+        application: Application identifier
+        decidim_organization_id: Organization
+        encryption_key: Encryption key
+        password: Password
+        user: User
   decidim:
     authorization_handlers:
       admin:
@@ -33,6 +39,30 @@ en:
         none: Without document
         passport: Passport
       invalid: Person not found in the municipal census.
+      organization_setting_not_found: Could not find the Municipal Census connection
+        configuration for organization %{organization}.
+      system_name: Municipal Census
+    system:
+      participando_organization_settings:
+        edit:
+          application_identifier: Application identifier
+          save: Save
+          select_organization: Select an organization
+          title: New Census Configuration
+        index:
+          description: This section allows you to configure the connection to the
+            Municipal Census service for your organization. If you enable this the
+            authorization handler without the proper configuration, users will receive
+            an error message when attempting to verify their identity through the
+            Municipal Census service.
+          new_setting: Add new configuration
+          no_settings: No configuration found for this organization.
+          participando_settings: Municipal Census settings
+          title: Municipal Census Configuration
+          updated_at: Updated at
+        update:
+          error: There was an error updating the Municipal Census configuration.
+          success: Municipal Census configuration updated successfully.
   open_data: Open Data
   open_government: Open Government of Navarra
   participation: Participation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,10 @@ en:
         password: Password
         user: User
   decidim:
+    admin_log:
+      participando_organization_setting:
+        update: "%{user_name} updated the %{resource_name} Municipal Census configuration
+          for organization %{organization_name}"
     authorization_handlers:
       admin:
         participando_authorization_handler:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,12 +12,18 @@ es:
           los datos de Identidad
         province_id: Provincia
         second_surname: Segundo apellido
-      participatory_process_type:
-        title: Título
   decidim:
     authorization_handlers:
+      admin:
+        participando_authorization_handler:
+          help:
+          - Este gestor de autorización permite verificar la identidad de un ciudadano
+            a través del servicio del Padrón Municipal.
       participando_authorization_handler:
         explanation: Verificación de datos del Padrón Municipal
+        fields:
+          birthdate: Fecha de nacimiento
+          document_type: Tipo de documento
         name: Padrón Municipal
     participando_authorization_handler:
       connection_error: No se ha podido conectar con el servicio del Padrón Municipal.
@@ -26,7 +32,7 @@ es:
         nif: NIF
         none: Sin documento
         passport: Pasaporte
-      invalid_participando_service_verification: Titular no identificado en el padrón municipal.
+      invalid: Titular no identificado en el padrón municipal.
   open_data: Datos Abiertos
   open_government: Gobierno Abierto de Navarra
   participation: Participación

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,6 +12,12 @@ es:
           los datos de Identidad
         province_id: Provincia
         second_surname: Segundo apellido
+      participando_organization_setting:
+        application: Identificador de aplicación
+        decidim_organization_id: Organización
+        encryption_key: Clave de cifrado
+        password: Contraseña Padrón Municipal
+        user: Usuario
   decidim:
     authorization_handlers:
       admin:
@@ -33,6 +39,30 @@ es:
         none: Sin documento
         passport: Pasaporte
       invalid: Titular no identificado en el padrón municipal.
+      organization_setting_not_found: No se ha encontrado la configuración de conexión
+        al Padrón Municipal para la organización %{organization}.
+      system_name: Padrón Municipal
+    system:
+      participando_organization_settings:
+        edit:
+          application_identifier: Identificador de aplicación
+          save: Guardar
+          select_organization: Seleccionar una organización
+          title: Nueva configuración del censo
+        index:
+          description: Esta sección le permite configurar la conexión al servicio
+            del Padrón Municipal para su organización. Si habilita este gestor de
+            autorización sin la configuración adecuada, los usuarios recibirán un
+            mensaje de error al intentar verificar su identidad a través del servicio
+            del Padrón Municipal.
+          new_setting: Agregar nueva configuración
+          no_settings: No se encontró configuración para esta organización.
+          participando_settings: Configuración del Padrón Municipal
+          title: Configuración del Padrón Municipal
+          updated_at: Actualizado el
+        update:
+          error: Hubo un error al actualizar la configuración del Padrón Municipal.
+          success: Configuración del Padrón Municipal actualizada correctamente.
   open_data: Datos Abiertos
   open_government: Gobierno Abierto de Navarra
   participation: Participación

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -19,6 +19,9 @@ es:
         password: Contraseña Padrón Municipal
         user: Usuario
   decidim:
+    admin_log:
+      participando_organization_setting:
+        update: "%{user_name} actualizó la configuración del Padrón Municipal de %{resource_name} para la organización %{organization_name}"
     authorization_handlers:
       admin:
         participando_authorization_handler:

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -12,21 +12,27 @@ eu:
           Nortasun datuak
         province_id: Probintzia
         second_surname: Bigarren abizena
-      participatory_process_type:
-        title: Izenburua
   decidim:
     authorization_handlers:
+      admin:
+        participando_authorization_handler:
+          help:
+          - Baimen kudeatzaile honek herritarren nortasuna egiaztatzeko aukera ematen
+            du Udal Erregistroaren zerbitzuaren bidez.
       participando_authorization_handler:
         explanation: Erregistro datuen egiaztapena
+        fields:
+          birthdate: Jaiotze data
+          document_type: Dokumentu mota
         name: Padrón
     participando_authorization_handler:
+      connection_error: Ezin izan da konektatu Udal Erroldaren zerbitzuarekin.
       document_types:
         nie: NIE
         nif: IFZ
         none: Dokumenturik gabe
         passport: Pasaporte
-      invalid_participando_service_verification: Identifikatu gabeko titularra edo bizileku
-        lurralde eremu okerra
+      invalid: Identifikatu gabeko titularra edo bizileku lurralde eremu okerra
   locale:
     name: Euskera
   open_data: Datu Irekiak

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -26,6 +26,8 @@ eu:
           document_type: Dokumentu mota
         name: Padrón
     participando_authorization_handler:
+      system_name: Padrón Municipal
+      organization_setting_not_found: Ez da aurkitu Udal Erroldaren konexioaren konfigurazioa %{organization} erakundearentzat.
       connection_error: Ezin izan da konektatu Udal Erroldaren zerbitzuarekin.
       document_types:
         nie: NIE

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,3 +12,8 @@ Rails.application.routes.draw do
   mount Decidim::Core::Engine => "/"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end
+
+# Add a simple menu in the admin part
+Decidim::System::Engine.routes.draw do
+  resources :participando_organization_settings, only: [:index, :edit, :update]
+end

--- a/db/migrate/20260619120000_create_participando_organization_settings.rb
+++ b/db/migrate/20260619120000_create_participando_organization_settings.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateParticipandoOrganizationSettings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :participando_organization_settings do |t|
+      t.references :decidim_organization, null: false, foreign_key: true, index: { unique: true }
+
+      t.text :application, null: false
+      t.text :user, null: false
+      t.text :password, null: false
+      t.text :encryption_key, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_04_141651) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_19_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "plpgsql"
@@ -907,58 +907,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_04_141651) do
     t.index ["decidim_user_group_id"], name: "index_decidim_debates_debates_on_decidim_user_group_id"
     t.index ["deleted_at"], name: "index_decidim_debates_debates_on_deleted_at"
     t.index ["likes_count"], name: "index_decidim_debates_debates_on_likes_count"
-  end
-
-  create_table "decidim_dev_coauthorable_dummy_resources", force: :cascade do |t|
-    t.jsonb "translatable_text"
-    t.string "title"
-    t.string "body"
-    t.text "address"
-    t.float "latitude"
-    t.float "longitude"
-    t.datetime "published_at"
-    t.datetime "deleted_at"
-    t.integer "coauthorships_count", default: 0, null: false
-    t.integer "likes_count", default: 0, null: false
-    t.integer "comments_count", default: 0, null: false
-    t.bigint "decidim_component_id"
-    t.bigint "decidim_category_id"
-    t.bigint "decidim_scope_id"
-    t.string "reference"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "decidim_dev_dummy_resources", force: :cascade do |t|
-    t.jsonb "translatable_text"
-    t.jsonb "title"
-    t.string "body"
-    t.text "address"
-    t.float "latitude"
-    t.float "longitude"
-    t.datetime "published_at"
-    t.datetime "deleted_at"
-    t.integer "coauthorships_count", default: 0, null: false
-    t.integer "likes_count", default: 0, null: false
-    t.integer "comments_count", default: 0, null: false
-    t.integer "follows_count", default: 0, null: false
-    t.bigint "decidim_component_id"
-    t.integer "decidim_author_id"
-    t.string "decidim_author_type"
-    t.integer "decidim_user_group_id"
-    t.bigint "decidim_category_id"
-    t.bigint "decidim_scope_id"
-    t.string "reference"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "decidim_dev_nested_dummy_resources", force: :cascade do |t|
-    t.jsonb "translatable_text"
-    t.string "title"
-    t.bigint "dummy_resource_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "decidim_editor_images", force: :cascade do |t|
@@ -2409,6 +2357,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_04_141651) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
+  create_table "participando_organization_settings", force: :cascade do |t|
+    t.bigint "decidim_organization_id", null: false
+    t.text "application", null: false
+    t.text "user", null: false
+    t.text "password", null: false
+    t.text "encryption_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decidim_organization_id"], name: "idx_on_decidim_organization_id_ebc449ebe2", unique: true
+  end
+
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
@@ -2490,4 +2449,5 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_04_141651) do
   add_foreign_key "oauth_access_tokens", "decidim_users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_applications", "decidim_organizations"
+  add_foreign_key "participando_organization_settings", "decidim_organizations"
 end

--- a/spec/commands/decidim/system/update_participando_organization_setting_spec.rb
+++ b/spec/commands/decidim/system/update_participando_organization_setting_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Decidim::System::UpdateParticipandoOrganizationSetting do
   subject(:command) { described_class.new(form, user) }
 
-  let(:user) { create(:admin, organization: organization) }
+  let(:user) { create(:user, :admin, organization: organization) }
   let(:organization) { create(:organization) }
 
   let(:form) do

--- a/spec/commands/decidim/system/update_participando_organization_setting_spec.rb
+++ b/spec/commands/decidim/system/update_participando_organization_setting_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Decidim::System::UpdateParticipandoOrganizationSetting do
+  subject(:command) { described_class.new(form, user) }
+
+  let(:user) { create(:admin, organization: organization) }
+  let(:organization) { create(:organization) }
+
+  let(:form) do
+    Decidim::System::ParticipandoOrganizationSettingForm.from_params(form_params).with_context(
+      current_organization: organization
+    )
+  end
+
+  let(:form_params) do
+    {
+      application: "new_app",
+      user: "new_user",
+      password: "new_password",
+      encryption_key: "new_encryption_key"
+    }
+  end
+
+  describe "call" do
+    context "when form is valid" do
+      context "when setting does not exist" do
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "creates a new ParticipandoOrganizationSetting" do
+          expect do
+            command.call
+          end.to change(ParticipandoOrganizationSetting, :count).by(1)
+        end
+
+        it "sets the correct attributes" do
+          command.call
+          setting = organization.participando_organization_setting
+          expect(setting.application).to eq("new_app")
+          expect(setting.user).to eq("new_user")
+          expect(setting.password).to eq("new_password")
+          expect(setting.encryption_key).to eq("new_encryption_key")
+        end
+      end
+
+      context "when setting already exists" do
+        let!(:existing_setting) do
+          create(:participando_organization_setting,
+                 organization: organization,
+                 application: "old_app",
+                 user: "old_user",
+                 password: "old_password",
+                 encryption_key: "old_encryption_key")
+        end
+
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "does not create a new ParticipandoOrganizationSetting" do
+          expect do
+            command.call
+          end.not_to change(ParticipandoOrganizationSetting, :count)
+        end
+
+        it "updates the existing setting" do
+          command.call
+          existing_setting.reload
+          expect(existing_setting.application).to eq("new_app")
+          expect(existing_setting.user).to eq("new_user")
+          expect(existing_setting.password).to eq("new_password")
+          expect(existing_setting.encryption_key).to eq("new_encryption_key")
+        end
+      end
+    end
+
+    context "when form is invalid" do
+      let(:form_params) do
+        {
+          application: nil,
+          user: "new_user",
+          password: "new_password",
+          encryption_key: "new_encryption_key"
+        }
+      end
+
+      it "broadcasts invalid" do
+        expect { command.call }.to broadcast(:invalid)
+      end
+
+      it "does not create or update a setting" do
+        expect do
+          command.call
+        end.not_to change(ParticipandoOrganizationSetting, :count)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,6 +9,12 @@ FactoryBot.define do
     application { "test_application" }
     user { "test_user" }
     password { "test_password" }
-    encryption_key { "test_encryption_key" }
+    encryption_key { "12345678901234567890123456789012" }
+  end
+
+  trait :with_participando_setting do
+    after(:create) do |organization|
+      create(:participando_organization_setting, organization: organization)
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,3 +2,13 @@
 
 require "decidim/core/test/factories"
 require "decidim/decidim_awesome/test/factories"
+
+FactoryBot.define do
+  factory :participando_organization_setting do
+    organization
+    application { "test_application" }
+    user { "test_user" }
+    password { "test_password" }
+    encryption_key { "test_encryption_key" }
+  end
+end

--- a/spec/forms/decidim/system/participando_organization_setting_form_spec.rb
+++ b/spec/forms/decidim/system/participando_organization_setting_form_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Decidim::System::ParticipandoOrganizationSettingForm do
+  subject(:form) { described_class.from_params(attributes) }
+
+  let(:attributes) do
+    {
+      application: "test_app",
+      user: "test_user",
+      password: "test_password",
+      encryption_key: "test_encryption_key"
+    }
+  end
+
+  describe "validations" do
+    context "when all required attributes are present" do
+      it { is_expected.to be_valid }
+    end
+
+    context "when application is missing" do
+      before { attributes.delete(:application) }
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error for application" do
+        form.valid?
+        expect(form.errors[:application]).not_to be_empty
+      end
+    end
+
+    context "when user is missing" do
+      before { attributes.delete(:user) }
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error for user" do
+        form.valid?
+        expect(form.errors[:user]).not_to be_empty
+      end
+    end
+
+    context "when password is missing" do
+      before { attributes.delete(:password) }
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error for password" do
+        form.valid?
+        expect(form.errors[:password]).not_to be_empty
+      end
+    end
+
+    context "when encryption_key is missing" do
+      before { attributes.delete(:encryption_key) }
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error for encryption_key" do
+        form.valid?
+        expect(form.errors[:encryption_key]).not_to be_empty
+      end
+    end
+
+    context "when multiple required attributes are missing" do
+      before do
+        attributes.delete(:application)
+        attributes.delete(:password)
+      end
+
+      it { is_expected.to be_invalid }
+
+      it "adds errors for missing attributes" do
+        form.valid?
+        expect(form.errors[:application]).not_to be_empty
+        expect(form.errors[:password]).not_to be_empty
+      end
+    end
+  end
+
+  describe "attributes" do
+    it "has application attribute" do
+      expect(form.application).to eq("test_app")
+    end
+
+    it "has user attribute" do
+      expect(form.user).to eq("test_user")
+    end
+
+    it "has password attribute" do
+      expect(form.password).to eq("test_password")
+    end
+
+    it "has encryption_key attribute" do
+      expect(form.encryption_key).to eq("test_encryption_key")
+    end
+  end
+end

--- a/spec/presenters/decidim/admin_log/participando_organization_setting_presenter_spec.rb
+++ b/spec/presenters/decidim/admin_log/participando_organization_setting_presenter_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Decidim::AdminLog::ParticipandoOrganizationSettingPresenter do
+  subject(:presenter) { described_class.new(action_log, view_helpers) }
+
+  let(:action_log) do
+    instance_double(
+      Decidim::ActionLog,
+      action: "update",
+      participatory_space: nil,
+      extra: {},
+      version: nil,
+      user: nil,
+      resource: nil,
+      created_at: Time.current
+    )
+  end
+  let(:view_helpers) { double("view_helpers") }
+
+  describe "private helpers" do
+    it "uses the participando organization setting labels" do
+      expect(presenter.send(:i18n_labels_scope)).to eq("activemodel.attributes.participando_organization_setting")
+    end
+
+    it "limits the diff to the configurable attributes" do
+      expect(presenter.send(:diff_fields_mapping)).to eq(
+        application: :string,
+        user: :string,
+        password: :string,
+        encryption_key: :string
+      )
+    end
+  end
+end

--- a/spec/services/participando_authorization_handler_spec.rb
+++ b/spec/services/participando_authorization_handler_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe ParticipandoAuthorizationHandler do
       first_surname: "Lopez",
       document_type: document_type,
       document_number: document_number,
-      date_of_birth: date_of_birth
+      date_of_birth: date_of_birth,
+      user: user
     )
   end
 
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, organization:) }
   let(:document_type) { :nif }
   let(:service_double) { instance_double(ParticipandoCensusWebservice) }
   let(:document_number) { "12345678A" }

--- a/spec/services/participando_census_webservice_spec.rb
+++ b/spec/services/participando_census_webservice_spec.rb
@@ -4,23 +4,28 @@ require "rails_helper"
 require "cgi"
 
 RSpec.describe ParticipandoCensusWebservice do
-  subject(:service) { described_class.new }
+  subject(:service) { described_class.new(organization) }
 
+  let(:organization) { create(:organization, :with_participando_setting) }
   let(:env_values) do
     {
       "PARTICIPANDO_URL" => "https://example.test",
       "PARTICIPANDO_ENTITY_NIF" => "B00000000",
-      "PARTICIPANDO_APPLICATION" => "PMH-UDALA",
-      "PARTICIPANDO_USER" => "demo",
-      "PARTICIPANDO_PASSWORD" => "password",
       "PARTICIPANDO_ENCRYPTION_KEY" => "12345678901234567890123456789012",
       "PARTICIPANDO_ENCRYPTION_VECTOR" => "Hello,FromANIMSA"
     }
   end
 
   before do
-    allow(ENV).to receive(:fetch) do |key|
-      env_values.fetch(key)
+    original_fetch = ENV.method(:fetch)
+    allow(ENV).to receive(:fetch) do |key, *args|
+      if env_values.key?(key)
+        env_values.fetch(key)
+      elsif args.empty?
+        original_fetch.call(key)
+      else
+        args.first
+      end
     end
   end
 

--- a/spec/services/participando_census_webservice_spec.rb
+++ b/spec/services/participando_census_webservice_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ParticipandoCensusWebservice do
   before do
     original_fetch = ENV.method(:fetch)
     allow(ENV).to receive(:fetch) do |key, *args|
-      if env_values.key?(key)
+      if env_values.has_key?(key)
         env_values.fetch(key)
       elsif args.empty?
         original_fetch.call(key)

--- a/spec/system/manage_participando_settings_spec.rb
+++ b/spec/system/manage_participando_settings_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin participando settings", perform_enqueued: true do
+  let(:admin) { create(:admin) }
+  let(:organization) { admin.organization }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+  end
+
+  describe "visiting participando settings index" do
+    it "shows the participando settings page" do
+      visit decidim_system.participando_organization_settings_path
+
+      expect(page).to have_content("Municipal Census Configuration")
+    end
+
+    it "lists all organizations" do
+      other_organization = create(:organization)
+
+      visit decidim_system.participando_organization_settings_path
+
+      expect(page).to have_content(organization.name)
+      expect(page).to have_content(other_organization.name)
+    end
+
+    context "when organization has a participando setting" do
+      let!(:setting) do
+        create(:participando_organization_setting,
+               organization:,
+               application: "test_app")
+      end
+
+      it "shows the application identifier" do
+        visit decidim_system.participando_organization_settings_path
+
+        expect(page).to have_content("test_app")
+      end
+
+      it "shows the updated date" do
+        visit decidim_system.participando_organization_settings_path
+
+        expect(page).to have_content(setting.updated_at.strftime("%d/%m/%Y"))
+      end
+    end
+
+    context "when organization does not have a participando setting" do
+      it "shows no settings message" do
+        visit decidim_system.participando_organization_settings_path
+
+        expect(page).to have_content("No configuration found for this organization")
+      end
+    end
+  end
+
+  describe "editing participando settings" do
+    context "when creating a new setting" do
+      it "loads the edit form" do
+        visit decidim_system.edit_participando_organization_setting_path(organization)
+
+        expect(page).to have_content("New Census Configuration")
+      end
+
+      it "has empty form fields" do
+        visit decidim_system.edit_participando_organization_setting_path(organization)
+
+        expect(page).to have_field("participando_organization_setting_form_application", with: "")
+        expect(page).to have_field("participando_organization_setting_form_user", with: "")
+        expect(page).to have_field("participando_organization_setting_form_password", with: "")
+        expect(page).to have_field("participando_organization_setting_form_encryption_key", with: "")
+      end
+
+      it "creates a new setting" do
+        visit decidim_system.edit_participando_organization_setting_path(organization)
+
+        fill_in "participando_organization_setting_form_application", with: "new_app"
+        fill_in "participando_organization_setting_form_user", with: "new_user"
+        fill_in "participando_organization_setting_form_password", with: "new_password"
+        fill_in "participando_organization_setting_form_encryption_key", with: "new_key"
+
+        click_button "Save"
+
+        expect(page).to have_content("configuration updated successfully")
+        expect(organization.reload.participando_organization_setting).to be_present
+        expect(organization.participando_organization_setting.application).to eq("new_app")
+      end
+    end
+
+    context "when updating an existing setting" do
+      let!(:setting) do
+        create(:participando_organization_setting,
+               organization:,
+               application: "old_app",
+               user: "old_user",
+               password: "old_password",
+               encryption_key: "old_key")
+      end
+
+      it "loads the edit form with existing data" do
+        visit decidim_system.edit_participando_organization_setting_path(organization)
+
+        expect(page).to have_field("participando_organization_setting_form_application", with: "old_app")
+        expect(page).to have_field("participando_organization_setting_form_user", with: "old_user")
+        expect(page).to have_field("participando_organization_setting_form_password", with: "old_password")
+        expect(page).to have_field("participando_organization_setting_form_encryption_key", with: "old_key")
+      end
+
+      it "updates the setting" do
+        visit decidim_system.edit_participando_organization_setting_path(organization)
+
+        fill_in "participando_organization_setting_form_application", with: "updated_app"
+        click_button "Save"
+
+        expect(page).to have_content("configuration updated successfully")
+        expect(setting.reload.application).to eq("updated_app")
+      end
+    end
+
+    context "when submitting invalid data" do
+      it "shows an error when application is empty" do
+        visit decidim_system.edit_participando_organization_setting_path(organization)
+
+        fill_in "participando_organization_setting_form_application", with: ""
+        fill_in "participando_organization_setting_form_user", with: "user"
+        fill_in "participando_organization_setting_form_password", with: "password"
+        fill_in "participando_organization_setting_form_encryption_key", with: "key"
+
+        click_button "Save"
+
+        expect(page).to have_content("There was an error updating the Municipal Census configuration")
+      end
+
+      it "shows an error when required fields are missing" do
+        visit decidim_system.edit_participando_organization_setting_path(organization)
+
+        click_button "Save"
+
+        expect(page).to have_content("There was an error updating the Municipal Census configuration")
+      end
+    end
+  end
+
+  describe "navigating from index to edit" do
+    it "can navigate to edit from index" do
+      visit decidim_system.participando_organization_settings_path
+
+      click_link "Edit"
+
+      expect(page).to have_current_path(decidim_system.edit_participando_organization_setting_path(organization))
+    end
+  end
+end

--- a/spec/system/manage_participando_settings_spec.rb
+++ b/spec/system/manage_participando_settings_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "Admin participando settings", perform_enqueued: true do
-  let(:admin) { create(:admin) }
+  let(:admin) { create(:user, :admin) }
   let(:organization) { admin.organization }
 
   before do

--- a/spec/system/manage_participando_settings_spec.rb
+++ b/spec/system/manage_participando_settings_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "ParticipandoOrganizationSetting", perform_enqueued: true do
+describe "Admin participando settings", perform_enqueued: true do
   let(:admin) { create(:admin) }
   let(:organization) { admin.organization }
 
@@ -67,19 +67,19 @@ describe "ParticipandoOrganizationSetting", perform_enqueued: true do
       it "has empty form fields" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        expect(page).to have_field("participando_organization_setting_form_application", with: "")
-        expect(page).to have_field("participando_organization_setting_form_user", with: "")
-        expect(page).to have_field("participando_organization_setting_form_password", with: "")
-        expect(page).to have_field("participando_organization_setting_form_encryption_key", with: "")
+        expect(page).to have_field("participando_organization_setting_application", with: "")
+        expect(page).to have_field("participando_organization_setting_user", with: "")
+        expect(page).to have_field("participando_organization_setting_password", with: "")
+        expect(page).to have_field("participando_organization_setting_encryption_key", with: "")
       end
 
       it "creates a new setting" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        fill_in "participando_organization_setting_form_application", with: "new_app"
-        fill_in "participando_organization_setting_form_user", with: "new_user"
-        fill_in "participando_organization_setting_form_password", with: "new_password"
-        fill_in "participando_organization_setting_form_encryption_key", with: "new_key"
+        fill_in "participando_organization_setting_application", with: "new_app"
+        fill_in "participando_organization_setting_user", with: "new_user"
+        fill_in "participando_organization_setting_password", with: "new_password"
+        fill_in "participando_organization_setting_encryption_key", with: "new_key"
 
         click_button "Save"
 
@@ -102,16 +102,16 @@ describe "ParticipandoOrganizationSetting", perform_enqueued: true do
       it "loads the edit form with existing data" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        expect(page).to have_field("participando_organization_setting_form_application", with: "old_app")
-        expect(page).to have_field("participando_organization_setting_form_user", with: "old_user")
-        expect(page).to have_field("participando_organization_setting_form_password", with: "old_password")
-        expect(page).to have_field("participando_organization_setting_form_encryption_key", with: "old_key")
+        expect(page).to have_field("participando_organization_setting_application", with: "old_app")
+        expect(page).to have_field("participando_organization_setting_user", with: "old_user")
+        expect(page).to have_field("participando_organization_setting_password", with: "old_password")
+        expect(page).to have_field("participando_organization_setting_encryption_key", with: "old_key")
       end
 
       it "updates the setting" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        fill_in "participando_organization_setting_form_application", with: "updated_app"
+        fill_in "participando_organization_setting_application", with: "updated_app"
         click_button "Save"
 
         expect(page).to have_content("configuration updated successfully")
@@ -123,10 +123,10 @@ describe "ParticipandoOrganizationSetting", perform_enqueued: true do
       it "shows an error when application is empty" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        fill_in "participando_organization_setting_form_application", with: ""
-        fill_in "participando_organization_setting_form_user", with: "user"
-        fill_in "participando_organization_setting_form_password", with: "password"
-        fill_in "participando_organization_setting_form_encryption_key", with: "key"
+        fill_in "participando_organization_setting_application", with: ""
+        fill_in "participando_organization_setting_user", with: "user"
+        fill_in "participando_organization_setting_password", with: "password"
+        fill_in "participando_organization_setting_encryption_key", with: "key"
 
         click_button "Save"
 

--- a/spec/system/manage_participando_settings_spec.rb
+++ b/spec/system/manage_participando_settings_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Admin participando settings", perform_enqueued: true do
+describe "ParticipandoOrganizationSetting", perform_enqueued: true do
   let(:admin) { create(:admin) }
   let(:organization) { admin.organization }
 

--- a/spec/system/manage_participando_settings_spec.rb
+++ b/spec/system/manage_participando_settings_spec.rb
@@ -3,19 +3,18 @@
 require "rails_helper"
 
 describe "Admin participando settings", perform_enqueued: true do
-  let(:admin) { create(:user, :admin) }
-  let(:organization) { admin.organization }
+  let(:admin) { Decidim::System::Admin.create!(email: "system-admin@example.org", password: "password123456", password_confirmation: "password123456") }
+  let(:organization) { create(:organization) }
 
   before do
-    switch_to_host(organization.host)
-    login_as admin, scope: :user
+    login_as admin, scope: :admin
   end
 
   describe "visiting participando settings index" do
     it "shows the participando settings page" do
       visit decidim_system.participando_organization_settings_path
 
-      expect(page).to have_content("Municipal Census Configuration")
+      expect(page).to have_content(I18n.t("decidim.system.participando_organization_settings.index.title"))
     end
 
     it "lists all organizations" do
@@ -23,8 +22,8 @@ describe "Admin participando settings", perform_enqueued: true do
 
       visit decidim_system.participando_organization_settings_path
 
-      expect(page).to have_content(organization.name)
-      expect(page).to have_content(other_organization.name)
+      expect(page).to have_content(organization.host)
+      expect(page).to have_content(other_organization.host)
     end
 
     context "when organization has a participando setting" do
@@ -51,7 +50,7 @@ describe "Admin participando settings", perform_enqueued: true do
       it "shows no settings message" do
         visit decidim_system.participando_organization_settings_path
 
-        expect(page).to have_content("No configuration found for this organization")
+        expect(page).to have_content(I18n.t("decidim.system.participando_organization_settings.index.no_settings"))
       end
     end
   end
@@ -61,7 +60,7 @@ describe "Admin participando settings", perform_enqueued: true do
       it "loads the edit form" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        expect(page).to have_content("New Census Configuration")
+        expect(page).to have_content(I18n.t("decidim.system.participando_organization_settings.edit.title"))
       end
 
       it "has empty form fields" do
@@ -81,9 +80,9 @@ describe "Admin participando settings", perform_enqueued: true do
         fill_in "participando_organization_setting_password", with: "new_password"
         fill_in "participando_organization_setting_encryption_key", with: "new_key"
 
-        click_button "Save"
+        click_button I18n.t("decidim.system.participando_organization_settings.edit.save")
 
-        expect(page).to have_content("configuration updated successfully")
+        expect(page).to have_content(I18n.t("decidim.system.participando_organization_settings.update.success"))
         expect(organization.reload.participando_organization_setting).to be_present
         expect(organization.participando_organization_setting.application).to eq("new_app")
       end
@@ -112,9 +111,9 @@ describe "Admin participando settings", perform_enqueued: true do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
         fill_in "participando_organization_setting_application", with: "updated_app"
-        click_button "Save"
+        click_button I18n.t("decidim.system.participando_organization_settings.edit.save")
 
-        expect(page).to have_content("configuration updated successfully")
+        expect(page).to have_content(I18n.t("decidim.system.participando_organization_settings.update.success"))
         expect(setting.reload.application).to eq("updated_app")
       end
     end
@@ -128,17 +127,17 @@ describe "Admin participando settings", perform_enqueued: true do
         fill_in "participando_organization_setting_password", with: "password"
         fill_in "participando_organization_setting_encryption_key", with: "key"
 
-        click_button "Save"
+        click_button I18n.t("decidim.system.participando_organization_settings.edit.save")
 
-        expect(page).to have_content("There was an error updating the Municipal Census configuration")
+        expect(page).to have_content(I18n.t("decidim.forms.errors.error"))
       end
 
       it "shows an error when required fields are missing" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        click_button "Save"
+        click_button I18n.t("decidim.system.participando_organization_settings.edit.save")
 
-        expect(page).to have_content("There was an error updating the Municipal Census configuration")
+        expect(page).to have_content(I18n.t("decidim.forms.errors.error"))
       end
     end
   end

--- a/spec/system/manage_participando_settings_spec.rb
+++ b/spec/system/manage_participando_settings_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Admin participando settings", perform_enqueued: true do
+describe "ManageParticipandoSettings", perform_enqueued: true do
   let(:admin) { Decidim::System::Admin.create!(email: "system-admin@example.org", password: "password123456", password_confirmation: "password123456") }
   let(:organization) { create(:organization) }
 


### PR DESCRIPTION
- [x] Fix locales
- [x] Configure namespace according to ENV (currently tempuri.org)
- [x] Configure verifier for each tenant (waiting until production credentials)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin index/edit/update UI to manage Participando (per-tenant) census credentials (application id, user, password, encryption key).
  * Stored credentials securely and surfaced updates in the admin audit log.
* **Bug Fixes**
  * Improved Participando authorization handling for missing/empty census responses and standardized invalid/error messaging across locales.
* **Documentation**
  * Updated README with Municipal Census configuration guidance and noted the admin setup page.
* **Tests**
  * Added coverage for the admin UI, settings form, update flow, presenter/handler behavior, and locale messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->