### PR TITLE
make nif dynamic instead of application

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Municipal Census service integration requires environment variables to be co
 ```bash
 # Required
 PARTICIPANDO_URL=https://www.animsa.es/ws/padron/v1
-PARTICIPANDO_ENTITY_NIF=XXXXXXXX
+PARTICIPANDO_APPLICATION=PMH-UDALA
 PARTICIPANDO_ENCRYPTION_VECTOR=XXXXXXXXXXXXXXXX  # 16-byte IV
 
 # Optional
@@ -51,7 +51,7 @@ PARTICIPANDO_SOAP_NAMESPACE=http://tempuri.org/  # Defaults to http://tempuri.or
 
 **Important:** Each tenant organization must be configured individually through the admin panel at `/system/participando_organization_settings` with their own credentials:
 
-- Application identifier
+- Entity NIF (CIFENTIDAD)
 - Username
 - Password
 - Encryption key (32-byte AES-256 key)

--- a/app/commands/decidim/system/update_participando_organization_setting.rb
+++ b/app/commands/decidim/system/update_participando_organization_setting.rb
@@ -16,7 +16,7 @@ module Decidim
         @setting = Decidim.traceability.update!(
           setting,
           user,
-          application: form.application,
+          entity_nif: form.entity_nif,
           user: form.user,
           password: form.password,
           encryption_key: form.encryption_key

--- a/app/forms/decidim/system/participando_organization_setting_form.rb
+++ b/app/forms/decidim/system/participando_organization_setting_form.rb
@@ -7,12 +7,12 @@ module Decidim
     class ParticipandoOrganizationSettingForm < Form
       mimic :participando_organization_setting
 
-      attribute :application, String
+      attribute :entity_nif, String
       attribute :user, String
       attribute :password, String
       attribute :encryption_key, String
 
-      validates :application, :user, :password, :encryption_key, presence: true
+      validates :entity_nif, :user, :password, :encryption_key, presence: true
     end
   end
 end

--- a/app/models/participando_organization_setting.rb
+++ b/app/models/participando_organization_setting.rb
@@ -9,13 +9,13 @@ class ParticipandoOrganizationSetting < ApplicationRecord
              foreign_key: :decidim_organization_id,
              inverse_of: :participando_organization_setting
 
-  encrypt_attribute :application, type: :text
+  encrypt_attribute :entity_nif, type: :text
   encrypt_attribute :user, type: :text
   encrypt_attribute :password, type: :text
   encrypt_attribute :encryption_key, type: :text
 
   validates :decidim_organization_id, uniqueness: true
-  validates :application, :user, :password, :encryption_key, presence: true
+  validates :entity_nif, :user, :password, :encryption_key, presence: true
 
   def self.log_presenter_class_for(_log)
     Decidim::AdminLog::ParticipandoOrganizationSettingPresenter

--- a/app/presenters/decidim/admin_log/participando_organization_setting_presenter.rb
+++ b/app/presenters/decidim/admin_log/participando_organization_setting_presenter.rb
@@ -9,7 +9,7 @@ module Decidim
 
       def diff_fields_mapping
         {
-          application: :string,
+          entity_nif: :string,
           user: :string,
           password: :string,
           encryption_key: :string

--- a/app/services/participando_census_webservice.rb
+++ b/app/services/participando_census_webservice.rb
@@ -10,11 +10,11 @@ require "digest"
 #
 # Required ENV vars (see .rbenv-vars):
 #   PARTICIPANDO_URL              - webservice endpoint
-#   PARTICIPANDO_ENTITY_NIF       - CIF of the entity (CIFENTIDAD)
+#   PARTICIPANDO_APPLICATION       - application identifier (e.g. PMH-UDALA)
 #   PARTICIPANDO_ENCRYPTION_VECTOR - 16-byte IV provided by ANIMSA
 #
 # Configuration is read from ParticipandoOrganizationSetting:
-#   application      - application identifier (e.g. PMH-UDALA)
+#   entity_nif       - CIF of the entity (CIFENTIDAD)
 #   user             - username provided by ANIMSA
 #   password         - base password provided by ANIMSA
 #   encryption_key   - 32-byte AES-256 key provided by ANIMSA
@@ -41,8 +41,8 @@ class ParticipandoCensusWebservice
     raise I18n.t("decidim.participando_authorization_handler.organization_setting_not_found", organization: organization.host) unless setting
 
     @url = ENV.fetch("PARTICIPANDO_URL")
-    @entity_nif = ENV.fetch("PARTICIPANDO_ENTITY_NIF")
-    @application = setting.application
+    @entity_nif = setting.entity_nif
+    @application = ENV.fetch("PARTICIPANDO_APPLICATION")
     @user = setting.user
     @password = setting.password
     @encryption_key = setting.encryption_key

--- a/app/views/decidim/system/participando_organization_settings/edit.html.erb
+++ b/app/views/decidim/system/participando_organization_settings/edit.html.erb
@@ -7,7 +7,7 @@
 <%= decidim_form_for(@form, url: decidim_system.participando_organization_setting_path(current_organization), method: :put) do |f| %>
   <div class="form__wrapper">
     <h2 class="h2"><%= organization_name(current_organization) %></h2>
-    <%= f.text_field :application, autofocus: true %>
+    <%= f.text_field :entity_nif, autofocus: true %>
 
     <%= f.text_field :user %>
 

--- a/app/views/decidim/system/participando_organization_settings/index.html.erb
+++ b/app/views/decidim/system/participando_organization_settings/index.html.erb
@@ -24,7 +24,7 @@
         </td>
         <% if organization.participando_organization_setting.present? %>
           <td class="text-left">
-            <%= organization.participando_organization_setting.application %>
+            <%= organization.participando_organization_setting.entity_nif %>
           </td>
           <td class="text-left">
             <%=  l organization.participando_organization_setting&.updated_at, format: :short %>

--- a/config/initializers/verifications.rb
+++ b/config/initializers/verifications.rb
@@ -2,7 +2,7 @@
 
 # ParticipandoAuthorizationHandler is a custom authorization handler that checks if a user is registered in the municipal census (padrón) using the ANIMSA-PMH web service.
 # It validates the user's personal information and document details against the census records to determine if they are authorized.
-# Requires to configure certain values in the /system panel for the organization, such as application identifier, user credentials, and encryption keys.
+# Requires to configure certain values in the /system panel for the organization, such as entity NIF, user credentials, and encryption keys.
 Decidim::Verifications.register_workflow(:participando_authorization_handler) do |workflow|
   workflow.form = "ParticipandoAuthorizationHandler"
   workflow.renewable = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
         province_id: Province
         second_surname: Second surname
       participando_organization_setting:
-        application: Application identifier
+        entity_nif: Entity NIF
         decidim_organization_id: Organization
         encryption_key: Encryption key
         password: Password
@@ -49,7 +49,7 @@ en:
     system:
       participando_organization_settings:
         edit:
-          application_identifier: Application identifier
+          entity_nif: Entity NIF
           save: Save
           select_organization: Select an organization
           title: New Census Configuration

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,7 +13,7 @@ es:
         province_id: Provincia
         second_surname: Segundo apellido
       participando_organization_setting:
-        application: Identificador de aplicación
+        entity_nif: NIF de la entidad
         decidim_organization_id: Organización
         encryption_key: Clave de cifrado
         password: Contraseña Padrón Municipal
@@ -48,7 +48,7 @@ es:
     system:
       participando_organization_settings:
         edit:
-          application_identifier: Identificador de aplicación
+          entity_nif: NIF de la entidad
           save: Guardar
           select_organization: Seleccionar una organización
           title: Nueva configuración del censo

--- a/db/migrate/20260623101500_rename_application_to_entity_nif_in_participando_organization_settings.rb
+++ b/db/migrate/20260623101500_rename_application_to_entity_nif_in_participando_organization_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameApplicationToEntityNifInParticipandoOrganizationSettings < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :participando_organization_settings, :application, :entity_nif
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_19_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_23_101500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "plpgsql"
@@ -907,6 +907,58 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_19_120000) do
     t.index ["decidim_user_group_id"], name: "index_decidim_debates_debates_on_decidim_user_group_id"
     t.index ["deleted_at"], name: "index_decidim_debates_debates_on_deleted_at"
     t.index ["likes_count"], name: "index_decidim_debates_debates_on_likes_count"
+  end
+
+  create_table "decidim_dev_coauthorable_dummy_resources", force: :cascade do |t|
+    t.jsonb "translatable_text"
+    t.string "title"
+    t.string "body"
+    t.text "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.datetime "published_at"
+    t.datetime "deleted_at"
+    t.integer "coauthorships_count", default: 0, null: false
+    t.integer "likes_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
+    t.bigint "decidim_component_id"
+    t.bigint "decidim_category_id"
+    t.bigint "decidim_scope_id"
+    t.string "reference"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "decidim_dev_dummy_resources", force: :cascade do |t|
+    t.jsonb "translatable_text"
+    t.jsonb "title"
+    t.string "body"
+    t.text "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.datetime "published_at"
+    t.datetime "deleted_at"
+    t.integer "coauthorships_count", default: 0, null: false
+    t.integer "likes_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
+    t.integer "follows_count", default: 0, null: false
+    t.bigint "decidim_component_id"
+    t.integer "decidim_author_id"
+    t.string "decidim_author_type"
+    t.integer "decidim_user_group_id"
+    t.bigint "decidim_category_id"
+    t.bigint "decidim_scope_id"
+    t.string "reference"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "decidim_dev_nested_dummy_resources", force: :cascade do |t|
+    t.jsonb "translatable_text"
+    t.string "title"
+    t.bigint "dummy_resource_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "decidim_editor_images", force: :cascade do |t|
@@ -2359,7 +2411,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_19_120000) do
 
   create_table "participando_organization_settings", force: :cascade do |t|
     t.bigint "decidim_organization_id", null: false
-    t.text "application", null: false
+    t.text "entity_nif", null: false
     t.text "user", null: false
     t.text "password", null: false
     t.text "encryption_key", null: false

--- a/spec/commands/decidim/system/update_participando_organization_setting_spec.rb
+++ b/spec/commands/decidim/system/update_participando_organization_setting_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Decidim::System::UpdateParticipandoOrganizationSetting do
 
   let(:form_params) do
     {
-      application: "new_app",
+      entity_nif: "B12345678",
       user: "new_user",
       password: "new_password",
       encryption_key: "new_encryption_key"
@@ -39,7 +39,7 @@ RSpec.describe Decidim::System::UpdateParticipandoOrganizationSetting do
         it "sets the correct attributes" do
           command.call
           setting = organization.participando_organization_setting
-          expect(setting.application).to eq("new_app")
+          expect(setting.entity_nif).to eq("B12345678")
           expect(setting.user).to eq("new_user")
           expect(setting.password).to eq("new_password")
           expect(setting.encryption_key).to eq("new_encryption_key")
@@ -50,7 +50,7 @@ RSpec.describe Decidim::System::UpdateParticipandoOrganizationSetting do
         let!(:existing_setting) do
           create(:participando_organization_setting,
                  organization: organization,
-                 application: "old_app",
+                 entity_nif: "B87654321",
                  user: "old_user",
                  password: "old_password",
                  encryption_key: "old_encryption_key")
@@ -69,7 +69,7 @@ RSpec.describe Decidim::System::UpdateParticipandoOrganizationSetting do
         it "updates the existing setting" do
           command.call
           existing_setting.reload
-          expect(existing_setting.application).to eq("new_app")
+          expect(existing_setting.entity_nif).to eq("B12345678")
           expect(existing_setting.user).to eq("new_user")
           expect(existing_setting.password).to eq("new_password")
           expect(existing_setting.encryption_key).to eq("new_encryption_key")
@@ -80,7 +80,7 @@ RSpec.describe Decidim::System::UpdateParticipandoOrganizationSetting do
     context "when form is invalid" do
       let(:form_params) do
         {
-          application: nil,
+          entity_nif: nil,
           user: "new_user",
           password: "new_password",
           encryption_key: "new_encryption_key"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,7 @@ require "decidim/decidim_awesome/test/factories"
 FactoryBot.define do
   factory :participando_organization_setting do
     organization
-    application { "test_application" }
+    entity_nif { "B00000000" }
     user { "test_user" }
     password { "test_password" }
     encryption_key { "12345678901234567890123456789012" }

--- a/spec/forms/decidim/system/participando_organization_setting_form_spec.rb
+++ b/spec/forms/decidim/system/participando_organization_setting_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Decidim::System::ParticipandoOrganizationSettingForm do
 
   let(:attributes) do
     {
-      application: "test_app",
+      entity_nif: "B12345678",
       user: "test_user",
       password: "test_password",
       encryption_key: "test_encryption_key"
@@ -19,14 +19,14 @@ RSpec.describe Decidim::System::ParticipandoOrganizationSettingForm do
       it { is_expected.to be_valid }
     end
 
-    context "when application is missing" do
-      before { attributes.delete(:application) }
+    context "when entity_nif is missing" do
+      before { attributes.delete(:entity_nif) }
 
       it { is_expected.to be_invalid }
 
-      it "adds an error for application" do
+      it "adds an error for entity_nif" do
         form.valid?
-        expect(form.errors[:application]).not_to be_empty
+        expect(form.errors[:entity_nif]).not_to be_empty
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Decidim::System::ParticipandoOrganizationSettingForm do
 
     context "when multiple required attributes are missing" do
       before do
-        attributes.delete(:application)
+        attributes.delete(:entity_nif)
         attributes.delete(:password)
       end
 
@@ -73,15 +73,15 @@ RSpec.describe Decidim::System::ParticipandoOrganizationSettingForm do
 
       it "adds errors for missing attributes" do
         form.valid?
-        expect(form.errors[:application]).not_to be_empty
+        expect(form.errors[:entity_nif]).not_to be_empty
         expect(form.errors[:password]).not_to be_empty
       end
     end
   end
 
   describe "attributes" do
-    it "has application attribute" do
-      expect(form.application).to eq("test_app")
+    it "has entity_nif attribute" do
+      expect(form.entity_nif).to eq("B12345678")
     end
 
     it "has user attribute" do

--- a/spec/presenters/decidim/admin_log/participando_organization_setting_presenter_spec.rb
+++ b/spec/presenters/decidim/admin_log/participando_organization_setting_presenter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Decidim::AdminLog::ParticipandoOrganizationSettingPresenter do
 
     it "limits the diff to the configurable attributes" do
       expect(presenter.send(:diff_fields_mapping)).to eq(
-        application: :string,
+        entity_nif: :string,
         user: :string,
         password: :string,
         encryption_key: :string

--- a/spec/services/participando_census_webservice_spec.rb
+++ b/spec/services/participando_census_webservice_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ParticipandoCensusWebservice do
   let(:env_values) do
     {
       "PARTICIPANDO_URL" => "https://example.test",
-      "PARTICIPANDO_ENTITY_NIF" => "B00000000",
+      "PARTICIPANDO_APPLICATION" => "PMH-UDALA",
       "PARTICIPANDO_ENCRYPTION_KEY" => "12345678901234567890123456789012",
       "PARTICIPANDO_ENCRYPTION_VECTOR" => "Hello,FromANIMSA"
     }

--- a/spec/system/manage_participando_settings_spec.rb
+++ b/spec/system/manage_participando_settings_spec.rb
@@ -30,13 +30,13 @@ describe "ManageParticipandoSettings", perform_enqueued: true do
       let!(:setting) do
         create(:participando_organization_setting,
                organization:,
-               application: "test_app")
+               entity_nif: "B12345678")
       end
 
-      it "shows the application identifier" do
+      it "shows the entity nif" do
         visit decidim_system.participando_organization_settings_path
 
-        expect(page).to have_content("test_app")
+        expect(page).to have_content("B12345678")
       end
 
       it "shows the updated date" do
@@ -66,7 +66,7 @@ describe "ManageParticipandoSettings", perform_enqueued: true do
       it "has empty form fields" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        expect(page).to have_field("participando_organization_setting_application", with: "")
+        expect(page).to have_field("participando_organization_setting_entity_nif", with: "")
         expect(page).to have_field("participando_organization_setting_user", with: "")
         expect(page).to have_field("participando_organization_setting_password", with: "")
         expect(page).to have_field("participando_organization_setting_encryption_key", with: "")
@@ -75,7 +75,7 @@ describe "ManageParticipandoSettings", perform_enqueued: true do
       it "creates a new setting" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        fill_in "participando_organization_setting_application", with: "new_app"
+        fill_in "participando_organization_setting_entity_nif", with: "B11111111"
         fill_in "participando_organization_setting_user", with: "new_user"
         fill_in "participando_organization_setting_password", with: "new_password"
         fill_in "participando_organization_setting_encryption_key", with: "new_key"
@@ -84,7 +84,7 @@ describe "ManageParticipandoSettings", perform_enqueued: true do
 
         expect(page).to have_content(I18n.t("decidim.system.participando_organization_settings.update.success"))
         expect(organization.reload.participando_organization_setting).to be_present
-        expect(organization.participando_organization_setting.application).to eq("new_app")
+        expect(organization.participando_organization_setting.entity_nif).to eq("B11111111")
       end
     end
 
@@ -92,7 +92,7 @@ describe "ManageParticipandoSettings", perform_enqueued: true do
       let!(:setting) do
         create(:participando_organization_setting,
                organization:,
-               application: "old_app",
+               entity_nif: "B22222222",
                user: "old_user",
                password: "old_password",
                encryption_key: "old_key")
@@ -101,7 +101,7 @@ describe "ManageParticipandoSettings", perform_enqueued: true do
       it "loads the edit form with existing data" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        expect(page).to have_field("participando_organization_setting_application", with: "old_app")
+        expect(page).to have_field("participando_organization_setting_entity_nif", with: "B22222222")
         expect(page).to have_field("participando_organization_setting_user", with: "old_user")
         expect(page).to have_field("participando_organization_setting_password", with: "old_password")
         expect(page).to have_field("participando_organization_setting_encryption_key", with: "old_key")
@@ -110,19 +110,19 @@ describe "ManageParticipandoSettings", perform_enqueued: true do
       it "updates the setting" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        fill_in "participando_organization_setting_application", with: "updated_app"
+        fill_in "participando_organization_setting_entity_nif", with: "B33333333"
         click_button I18n.t("decidim.system.participando_organization_settings.edit.save")
 
         expect(page).to have_content(I18n.t("decidim.system.participando_organization_settings.update.success"))
-        expect(setting.reload.application).to eq("updated_app")
+        expect(setting.reload.entity_nif).to eq("B33333333")
       end
     end
 
     context "when submitting invalid data" do
-      it "shows an error when application is empty" do
+      it "shows an error when entity_nif is empty" do
         visit decidim_system.edit_participando_organization_setting_path(organization)
 
-        fill_in "participando_organization_setting_application", with: ""
+        fill_in "participando_organization_setting_entity_nif", with: ""
         fill_in "participando_organization_setting_user", with: "user"
         fill_in "participando_organization_setting_password", with: "password"
         fill_in "participando_organization_setting_encryption_key", with: "key"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with revised environment variable requirements for Participando configuration.

* **Improvements**
  * Updated Participando integration to use entity NIF instead of application identifier for organization credentials.
  * Revised admin panel organization settings form with new field labels and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->